### PR TITLE
missing MSIM Layouts

### DIFF
--- a/packages/SystemUI/res/layout/msim_status_bar.xml
+++ b/packages/SystemUI/res/layout/msim_status_bar.xml
@@ -45,8 +45,8 @@
     <LinearLayout android:id="@+id/status_bar_contents"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingStart="6dip"
-        android:paddingEnd="6dip"
+        android:paddingStart="6dp"
+        android:paddingEnd="8dp"
         android:orientation="horizontal"
         >
 
@@ -97,6 +97,14 @@
             android:orientation="horizontal"
             >
 
+            <com.android.systemui.statusbar.policy.Traffic
+                android:id="@+id/traffic"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:singleLine="false"
+                android:gravity="right|center_vertical"
+                />
+
             <include layout="@layout/msim_system_icons" />
 
             <com.android.systemui.BatteryLevelTextView android:id="@+id/battery_level_text"
@@ -113,7 +121,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:singleLine="true"
-                android:paddingStart="6dip"
+                android:paddingStart="7dp"
                 android:gravity="center_vertical|start"
                 />
         </com.android.keyguard.AlphaOptimizedLinearLayout>
@@ -145,5 +153,11 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />
+
+    <com.android.systemui.statusbar.policy.BatteryBarController
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:visibility="gone"
+        systemui:viewLocation="1" />
 
 </com.android.systemui.statusbar.phone.PhoneStatusBarView>


### PR DESCRIPTION
fixes the SystemUI FC loops in msim phone on boot 